### PR TITLE
Fix a typo in the main docs page (rough -> rc)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ npm install --save roughjs
 
 ```js
 const rc = rough.canvas(document.getElementById('canvas'));
-rough.rectangle(10, 10, 200, 200); // x, y, width, height
+rc.rectangle(10, 10, 200, 200); // x, y, width, height
 ```
 
 ### Lines and Ellipses


### PR DESCRIPTION
Hey there! I noticed that the documentation in the `docs` folder didn't match that in the `README`. I'm not sure how the documentation website gets generated, but I gather that changing `docs/README.md` would probably do it - went ahead and changed an incorrect reference of `rough` to `rc`.

I believe the github web UI fixed the end-of-file too.