### PR TITLE
implement dashed lines

### DIFF
--- a/src/canvas-base.ts
+++ b/src/canvas-base.ts
@@ -26,6 +26,7 @@ export abstract class RoughCanvasBase {
       switch (drawing.type) {
         case 'path':
           ctx.save();
+          ctx.setLineDash(o.lineDash);
           ctx.strokeStyle = o.stroke;
           ctx.lineWidth = o.strokeWidth;
           this._drawToContext(ctx, drawing);

--- a/src/core.ts
+++ b/src/core.ts
@@ -40,6 +40,7 @@ export interface ResolvedOptions extends Options {
   fillWeight: number;
   hachureAngle: number;
   hachureGap: number;
+  lineDash: Array<number>;
 }
 
 export declare type OpType = 'move' | 'bcurveTo' | 'lineTo' | 'qcurveTo';

--- a/src/generator-base.ts
+++ b/src/generator-base.ts
@@ -20,7 +20,8 @@ export abstract class RoughGeneratorBase {
     fillStyle: 'hachure',
     fillWeight: -1,
     hachureAngle: -41,
-    hachureGap: -1
+    hachureGap: -1,
+    lineDash: [],
   };
 
   constructor(config: Config | null, surface: DrawingSurface) {

--- a/src/svg-base.ts
+++ b/src/svg-base.ts
@@ -49,6 +49,9 @@ export abstract class RoughSVGBase {
           path.style.stroke = o.stroke;
           path.style.strokeWidth = o.strokeWidth + '';
           path.style.fill = 'none';
+          if (o.lineDash && o.lineDash.length > 0) {
+            path.style.strokeDasharray = o.lineDash.join(' ');
+          }
           break;
         }
         case 'fillPath': {


### PR DESCRIPTION
Implement dashed lines. 

for canvas  ( [setLineDash](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash)):

```js
const rc = rough.canvas(document.getElementById('canvas'));
rc.rectangle(10, 10, 200, 200, {lineDash: [10, 20]});
```

for svg  ([stroke-dash-array](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/stroke-dasharray)):

```js
const rc = rough.svg(svg);
let node = rc.rectangle(10, 10, 200, 200, {lineDash: [10, 20]});
svg.appendChild(node);
```
![](https://p0.ssl.qhimg.com/t01e8f312fa996579d8.jpg)
