### PR TITLE
Clone default settings before using it in generator

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -43,7 +43,7 @@ export class RoughGenerator {
   }
 
   private _options(options?: Options): ResolvedOptions {
-    return options ? Object.assign({}, this.defaultOptions, options) : this.defaultOptions;
+    return Object.assign({}, this.defaultOptions, options || {});
   }
 
   private _drawable(shape: string, sets: OpSet[], options: ResolvedOptions): Drawable {


### PR DESCRIPTION
There are some parts in the renderer where the options object is being mutated by some functions (e.g [_line function in renderer](https://github.com/pshihn/rough/blob/master/src/renderer.ts#L234)). If you are using custom parameters, because default parameters and the custom parameters are merged, the resulting object is a cloned object that we can work on. However, if custom parameters are not passed to these functions, the original value of the default parameters will be used. As a result, any custom object that doesn't specify a value will be overridden by the changing default value.

By cloning default options we can always preserve the original default values, which will stop bleeding of parameters between rendered elements.