### PR TITLE
Same increment for arc filling and path

### DIFF
--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -201,7 +201,7 @@ export function patternFillArc(x: number, y: number, width: number, height: numb
     strt = 0;
     stp = Math.PI * 2;
   }
-  const increment = (stp - strt) / o.curveStepCount;
+  const increment = Math.min(Math.PI  / o.curveStepCount, (stp - strt) / 2);
   const points: Point[] = [];
   for (let angle = strt; angle <= stp; angle = angle + increment) {
     points.push([cx + rx * Math.cos(angle), cy + ry * Math.sin(angle)]);


### PR DESCRIPTION
The current calculation of radial increment is different for arc filling and drawing, making it very different in case of  a low `curveStepCount` This change copies the increment calculation from drawing to filling for a better adjustment.